### PR TITLE
[Tests] Add fuzz test for AlphaNumeric

### DIFF
--- a/sanitize_fuzz_test.go
+++ b/sanitize_fuzz_test.go
@@ -1,0 +1,33 @@
+package sanitize_test
+
+import (
+	"testing"
+	"unicode"
+
+	"github.com/mrz1836/go-sanitize"
+)
+
+// FuzzAlphaNumeric validates that AlphaNumeric only returns letters, digits and optional spaces.
+func FuzzAlphaNumeric_General(f *testing.F) {
+	seed := []struct {
+		input  string
+		spaces bool
+	}{
+		{"Example 123!", false},
+		{"Another Example 456?", true},
+	}
+	for _, tc := range seed {
+		f.Add(tc.input, tc.spaces)
+	}
+	f.Fuzz(func(t *testing.T, input string, spaces bool) {
+		out := sanitize.AlphaNumeric(input, spaces)
+		for _, r := range out {
+			if spaces && r == ' ' {
+				continue
+			}
+			if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+				t.Fatalf("invalid rune %q in %q", r, out)
+			}
+		}
+	})
+}


### PR DESCRIPTION
### What Changed
- add `FuzzAlphaNumeric_General` as a new fuzz test

### Why It Was Necessary
- provide an example of Go fuzz testing which is supported from Go 1.18 onward

### Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

### Impact / Risk
- minimal risk: adds a new test file only

------
https://chatgpt.com/codex/tasks/task_e_6850af18ac248321a51afbb3065ded88