### PR TITLE
[Sanitize] Add CustomCompiled helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ View the generated [documentation](https://pkg.go.dev/github.com/mrz1836/go-sani
 - Alpha and alphanumeric sanitization with optional spaces
 - Bitcoin and Bitcoin Cash address sanitizers
 - Custom regular expression helper for arbitrary patterns
+- Precompiled regex sanitizer for repeated patterns
 - Decimal, domain, email and IP address normalization
 - HTML and XML stripping with script removal
 - URI, URL and XSS sanitization
@@ -142,6 +143,7 @@ View the generated [documentation](https://pkg.go.dev/github.com/mrz1836/go-sani
 - [`BitcoinAddress`](sanitize.go): Filter input to valid Bitcoin address characters
 - [`BitcoinCashAddress`](sanitize.go): Filter input to valid Bitcoin Cash address characters
 - [`Custom`](sanitize.go): Use a custom regex to filter input
+- [`CustomCompiled`](sanitize.go): Use a precompiled regex to filter input
 - [`Decimal`](sanitize.go): Keep only decimal or float characters
 - [`Domain`](sanitize.go): Sanitize domain, optionally preserving case and removing www
 - [`Email`](sanitize.go): Normalize an email address
@@ -316,6 +318,7 @@ Performance benchmarks for the core functions in this library, executed on an Ap
 | [BenchmarkBitcoinAddress](sanitize_test.go)           | 2,156,088  |   555.2 |  160 |         4 |
 | [BenchmarkBitcoinCashAddress](sanitize_test.go)       | 1,619,050  |   744.5 |  160 |         4 |
 | [BenchmarkCustom](sanitize_test.go)                   | 879,280    | 1,279.0 |  943 |        17 |
+| [BenchmarkCustomCompiled](sanitize_test.go)           | 795,579    | 1,476.0 |   96 |         5 |
 | [BenchmarkDecimal](sanitize_test.go)                  | 2,035,514  |   595.4 |   56 |         3 |
 | [BenchmarkDomain](sanitize_test.go)                   | 2,493,144  |   473.0 |  225 |         6 |
 | [BenchmarkDomain\_PreserveCase](sanitize_test.go)     | 2,879,966  |   420.9 |  209 |         5 |

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"log"
+	"regexp"
 
 	"github.com/mrz1836/go-sanitize"
 )
@@ -27,6 +28,10 @@ func main() {
 	// Custom allows any regular expression for sanitization.
 	customIn := "Sample #1 String"
 	log.Printf("Custom(%q, `[^a-zA-Z]`) => %q\n", customIn, sanitize.Custom(customIn, `[^a-zA-Z]`))
+
+	// CustomCompiled uses a precompiled regular expression for speed.
+	re := regexp.MustCompile(`[^a-zA-Z]`)
+	log.Printf("CustomCompiled(%q) => %q\n", customIn, sanitize.CustomCompiled(customIn, re))
 
 	// Decimal keeps digits and decimal separators.
 	decIn := "$ -99.99!"

--- a/sanitize.go
+++ b/sanitize.go
@@ -192,6 +192,29 @@ func Custom(original string, regExp string) string {
 	return string(regexp.MustCompile(regExp).ReplaceAll([]byte(original), emptySpace))
 }
 
+// CustomCompiled returns a sanitized string using a pre-compiled regular
+// expression. This function provides better performance when the same pattern is
+// reused across multiple calls.
+//
+// Parameters:
+// - original: The input string to be sanitized.
+// - re: A compiled regular expression used for sanitization.
+//
+// Returns:
+// - A sanitized string based on the provided regular expression.
+//
+// Example:
+//
+//	input := "Hello, World! 123"
+//	customRegExp := regexp.MustCompile(`[^a-zA-Z\s]`)
+//	result := sanitize.CustomCompiled(input, customRegExp)
+//	fmt.Println(result) // Output: "Hello World"
+//
+// View more examples in the `sanitize_test.go` file.
+func CustomCompiled(original string, re *regexp.Regexp) string {
+	return re.ReplaceAllString(original, "")
+}
+
 // Decimal returns a sanitized string containing only decimal/float values, including positive and negative numbers.
 // This function removes any characters that are not part of the accepted decimal format.
 //

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -2,6 +2,7 @@ package sanitize_test
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -253,6 +254,28 @@ func ExampleCustom() {
 func ExampleCustom_numeric() {
 	fmt.Println(sanitize.Custom("Example String 2!", `[^0-9]`))
 	// Output: 2
+}
+
+// TestCustomCompiled verifies CustomCompiled using a precompiled regex
+func TestCustomCompiled_Basic(t *testing.T) {
+	re := regexp.MustCompile(`[^a-zA-Z0-9]`)
+	output := sanitize.CustomCompiled("Works 123!", re)
+	assert.Equal(t, "Works123", output)
+}
+
+// BenchmarkCustomCompiled benchmarks the CustomCompiled method
+func BenchmarkCustomCompiled(b *testing.B) {
+	re := regexp.MustCompile(`[^a-zA-Z0-9]`)
+	for i := 0; i < b.N; i++ {
+		_ = sanitize.CustomCompiled("This is the test string 12345.", re)
+	}
+}
+
+// ExampleCustomCompiled example using CustomCompiled with an alpha regex
+func ExampleCustomCompiled() {
+	re := regexp.MustCompile(`[^a-zA-Z]`)
+	fmt.Println(sanitize.CustomCompiled("Example String 2!", re))
+	// Output: ExampleString
 }
 
 // TestDecimal tests the decimal sanitize method


### PR DESCRIPTION
## What Changed
- implemented `CustomCompiled` for using precompiled regex patterns
- added unit test, benchmark, and example demonstrating usage
- documented function in `README` and example program
- updated benchmark results table

## Why It Was Necessary
- improves performance when the same regular expression is reused
- expands library API for more efficient sanitization options

## Testing Performed
- `go test ./...`
- `golangci-lint run`
- benchmark `CustomCompiled` to record performance numbers

## Impact / Risk
- no breaking changes
- minimal regression risk as function is additive


------
https://chatgpt.com/codex/tasks/task_e_68515f92bafc83219784d9926b285096