### PR TITLE
[Test] Expand CustomCompiled coverage

### DIFF
--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -258,9 +258,29 @@ func ExampleCustom_numeric() {
 
 // TestCustomCompiled verifies CustomCompiled using a precompiled regex
 func TestCustomCompiled_Basic(t *testing.T) {
-	re := regexp.MustCompile(`[^a-zA-Z0-9]`)
-	output := sanitize.CustomCompiled("Works 123!", re)
-	assert.Equal(t, "Works123", output)
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		re       *regexp.Regexp
+	}{
+		{"alpha numeric", "Works 123!", "Works123", regexp.MustCompile(`[^a-zA-Z0-9]`)},
+		{"decimal", "ThisWorks1.23!", "1.23", regexp.MustCompile(`[^0-9.-]`)},
+		{"numbers and letters", "ThisWorks1.23!", "ThisWorks123", regexp.MustCompile(`[^0-9a-zA-Z]`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := sanitize.CustomCompiled(tt.input, tt.re)
+			assert.Equal(t, tt.expected, output)
+		})
+	}
+}
+
+func TestCustomCompiled_NilRegex(t *testing.T) {
+	require.Panics(t, func() {
+		sanitize.CustomCompiled("panic", nil)
+	})
 }
 
 // BenchmarkCustomCompiled benchmarks the CustomCompiled method


### PR DESCRIPTION
**Assign to:** @mrz1836

## What Changed
- expanded `TestCustomCompiled_Basic` to run multiple regex scenarios
- added `TestCustomCompiled_NilRegex` to verify panic on nil input

## Why It Was Necessary
- current tests only covered a single pattern; nil regex behavior was untested

## Testing Performed
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- no breaking changes; increases unit test coverage for edge cases

------
https://chatgpt.com/codex/tasks/task_e_6851662d4cb88321bf5a383d547bee36