### PR TITLE
[Testing] Add fuzz test for Alpha

### DIFF
--- a/sanitize_fuzz_test.go
+++ b/sanitize_fuzz_test.go
@@ -31,3 +31,27 @@ func FuzzAlphaNumeric_General(f *testing.F) {
 		}
 	})
 }
+
+// FuzzAlpha_General validates that Alpha only returns letters and optional spaces.
+func FuzzAlpha_General(f *testing.F) {
+	seed := []struct {
+		input  string
+		spaces bool
+	}{
+		{"Example 123!", false},
+		{"Another Example 456?", true},
+	}
+	for _, tc := range seed {
+		f.Add(tc.input, tc.spaces)
+	}
+	f.Fuzz(func(t *testing.T, input string, spaces bool) {
+		out := sanitize.Alpha(input, spaces)
+		for _, r := range out {
+			if spaces && r == ' ' {
+				continue
+			}
+			require.Truef(t, unicode.IsLetter(r),
+				"invalid rune %q in %q (input: %q, spaces: %v)", r, out, input, spaces)
+		}
+	})
+}


### PR DESCRIPTION
## What Changed
- added `FuzzAlpha_General` to validate `Alpha` only keeps letters and optional spaces

## Why It Was Necessary
- to improve fuzz coverage for `Alpha` similar to existing `AlphaNumeric` fuzz test

## Testing Performed
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`

## Impact / Risk
- no breaking changes; adds test coverage only.

------
https://chatgpt.com/codex/tasks/task_e_68516838f0fc83219fe66bb764c0e152