### PR TITLE
[TEST] Add fuzz test for BitcoinAddress

### DIFF
--- a/sanitize_fuzz_test.go
+++ b/sanitize_fuzz_test.go
@@ -55,3 +55,27 @@ func FuzzAlpha_General(f *testing.F) {
 		}
 	})
 }
+
+// FuzzBitcoinAddress_General validates that BitcoinAddress only returns valid Bitcoin address characters.
+func FuzzBitcoinAddress_General(f *testing.F) {
+	seed := []string{
+		":1K6c7LGpdB8LwoGNVfG51dRV9UUEijbrWs!",
+		"OIl01K6c7LGpdB8LwoGNVfG51dRV9UUEijbrWs!",
+	}
+	for _, tc := range seed {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		out := sanitize.BitcoinAddress(input)
+		for _, r := range out {
+			valid := (r >= 'a' && r <= 'k') ||
+				(r >= 'm' && r <= 'z') ||
+				(r >= 'A' && r <= 'H') ||
+				(r >= 'J' && r <= 'N') ||
+				(r >= 'P' && r <= 'Z') ||
+				(r >= '1' && r <= '9')
+			require.Truef(t, valid,
+				"invalid rune %q in %q (input: %q)", r, out, input)
+		}
+	})
+}


### PR DESCRIPTION
## What Changed
- added `FuzzBitcoinAddress_General` to cover sanitization logic

## Why It Was Necessary
- improves test coverage for Bitcoin address filtering and guards against edge cases

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `go test -run=^$ -fuzz=FuzzAlphaNumeric_General -fuzztime=1s`
- `go test -run=^$ -fuzz=FuzzAlpha_General -fuzztime=1s`
- `go test -run=^$ -fuzz=FuzzBitcoinAddress_General -fuzztime=1s`

## Impact / Risk
- no breaking changes
- minimal risk; test additions only

------
https://chatgpt.com/codex/tasks/task_e_68516e517eec8321a0638c305f564d8d