### PR TITLE
[Test] Add fuzz tests for Numeric, PathName, Punctuation

### DIFF
--- a/sanitize_fuzz_test.go
+++ b/sanitize_fuzz_test.go
@@ -205,3 +205,61 @@ func FuzzIPAddress_General(f *testing.F) {
 		require.Equal(t, ip.String(), out)
 	})
 }
+
+// FuzzNumeric_General validates that Numeric only returns digits.
+func FuzzNumeric_General(f *testing.F) {
+	seed := []string{
+		"Phone: 123-456-7890",
+		"Order #987654321",
+	}
+	for _, tc := range seed {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		out := sanitize.Numeric(input)
+		for _, r := range out {
+			require.Truef(t, unicode.IsDigit(r),
+				"invalid rune %q in %q (input: %q)", r, out, input)
+		}
+	})
+}
+
+// FuzzPathName_General validates that PathName only returns valid pathname characters.
+func FuzzPathName_General(f *testing.F) {
+	seed := []string{
+		"file:name/with*invalid|chars",
+		"another path\\with spaces.txt",
+	}
+	for _, tc := range seed {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		out := sanitize.PathName(input)
+		for _, r := range out {
+			valid := unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_'
+			require.Truef(t, valid,
+				"invalid rune %q in %q (input: %q)", r, out, input)
+		}
+	})
+}
+
+// FuzzPunctuation_General validates that Punctuation only returns letters, digits, spaces, and standard punctuation.
+func FuzzPunctuation_General(f *testing.F) {
+	seed := []string{
+		"Hello, World! How's it going? (Good, I hope.)",
+		"Testing #1 & #2: \"quotes\" and punctuation!",
+	}
+	for _, tc := range seed {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		out := sanitize.Punctuation(input)
+		for _, r := range out {
+			valid := unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '\'' ||
+				r == '"' || r == '#' || r == '&' || r == '!' || r == '?' || r == ',' ||
+				r == '.' || unicode.IsSpace(r)
+			require.Truef(t, valid,
+				"invalid rune %q in %q (input: %q)", r, out, input)
+		}
+	})
+}


### PR DESCRIPTION
## What Changed
- Added fuzz tests for `Numeric`, `PathName`, and `Punctuation`
- Seeded new fuzzers with representative input values
- Verified output runes match allowed character sets

## Why It Was Necessary
- Increases test coverage of sanitization functions
- Helps detect unexpected edge cases in numeric, path, and punctuation handling

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `go test -run=^$ -fuzz=FuzzNumeric_General -fuzztime=1x`
- `go test -run=^$ -fuzz=FuzzPathName_General -fuzztime=1x`
- `go test -run=^$ -fuzz=FuzzPunctuation_General -fuzztime=1x`

## Impact / Risk
- No breaking changes
- Minimal risk since changes only introduce additional tests


------
https://chatgpt.com/codex/tasks/task_e_6851753a546c832195e3b9220cfa7998