### PR TITLE
[sanitize] Iterate runes in PathName

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -38,7 +38,6 @@ var (
 	formalNameRegExp         = regexp.MustCompile(`[^a-zA-Z0-9-',.\s]`)                                                       // Characters recognized in surnames and proper names
 	htmlRegExp               = regexp.MustCompile(`(?i)<[^>]*>`)                                                              // HTML/XML tags or any alligator open/close tags
 	ipAddressRegExp          = regexp.MustCompile(`[^a-zA-Z0-9:.]`)                                                           // IPV4 and IPV6 characters only
-	pathNameRegExp           = regexp.MustCompile(`[^a-zA-Z0-9-_]`)                                                           // Path name (file name, seo)
 	punctuationRegExp        = regexp.MustCompile(`[^a-zA-Z0-9-'"#&!?,.\s]+`)                                                 // Standard accepted punctuation characters
 	scientificNotationRegExp = regexp.MustCompile(`[^0-9.eE+-]`)                                                              // Scientific Notation (float) (positive and negative)
 	scriptRegExp             = regexp.MustCompile(`(?i)<(script|iframe|embed|object)[^>]*>.*</(script|iframe|embed|object)>`) // Scripts and embeds
@@ -475,7 +474,21 @@ func Numeric(original string) string {
 //
 // See more usage examples in the `sanitize_test.go` file.
 func PathName(original string) string {
-	return string(pathNameRegExp.ReplaceAll([]byte(original), emptySpace))
+	var b strings.Builder
+	b.Grow(len(original))
+	for _, r := range original {
+		switch {
+		case '0' <= r && r <= '9':
+			b.WriteRune(r)
+		case 'a' <= r && r <= 'z':
+			b.WriteRune(r)
+		case 'A' <= r && r <= 'Z':
+			b.WriteRune(r)
+		case r == '-' || r == '_':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // Punctuation returns a string with basic punctuation preserved.


### PR DESCRIPTION
## What Changed
- removed regex allocation for `PathName`
- iterated over runes directly to filter valid characters

## Why It Was Necessary
- align `PathName` with other rune-based sanitizers to avoid allocations and simplify logic

## Testing Performed
- `go fmt ./...`
- `goimports -w sanitize.go sanitize_test.go examples/examples.go sanitize_fuzz_test.go`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`
- `make govulncheck` *(reported GO-2025-3750 from stdlib)*

## Impact / Risk
- No breaking API changes
- Slight behavior change if non-ASCII letters were previously removed, which remains consistent


------
https://chatgpt.com/codex/tasks/task_e_6851a7ea53f483219f482ee4ec706fbb