### PR TITLE
[sanitize] Add edge tests for Time

### DIFF
--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1088,6 +1088,27 @@ func ExampleTime() {
 	// Output: 01:02:03
 }
 
+// TestTime_EdgeCases tests additional edge cases for the Time sanitize method
+func TestTime_EdgeCases(t *testing.T) {
+
+	var tests = []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"abc", ""},
+		{"10:20PM", "10:20"},
+		{"-10:20", "10:20"},
+		{"12:34:56.789", "12:34:56789"},
+		{"10\n:20\t:30", "10:20:30"},
+	}
+
+	for _, test := range tests {
+		output := sanitize.Time(test.input)
+		assert.Equal(t, test.expected, output)
+	}
+}
+
 // TestURI tests the URI sanitize method
 func TestURI_Basic(t *testing.T) {
 


### PR DESCRIPTION
## What Changed
- added TestTime_EdgeCases covering blank, alphabetic, trailing characters, and escape sequences

## Why It Was Necessary
- strengthen test coverage for `Time` sanitizer by including additional edge cases

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- no breaking changes; expands unit tests only


------
https://chatgpt.com/codex/tasks/task_e_6851abed88c4832184bd71b262b626d6