### PR TITLE
Expand FormalName edge cases

### DIFF
--- a/sanitize_fuzz_test.go
+++ b/sanitize_fuzz_test.go
@@ -201,7 +201,16 @@ func FuzzFirstToUpper_General(f *testing.F) {
 // FuzzFormalName_General validates that FormalName only returns characters
 // typically allowed in proper names.
 func FuzzFormalName_General(f *testing.F) {
-	seed := []string{"Mark Mc'Cuban-Host", "Does #Not Work!"}
+	seed := []string{
+		"Mark Mc'Cuban-Host",
+		"Does #Not Work!",
+		"O'Leary-Brown",
+		"d'Artagnan",
+		"D’Angelo",
+		"Van  der  Meer",
+		"Émilie du Châtelet",
+		"Björk Guðmundsdóttir",
+	}
 	for _, tc := range seed {
 		f.Add(tc)
 	}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -688,6 +688,12 @@ func TestFormalName_EdgeCases(t *testing.T) {
 		{"digits", "John Doe 3rd", "John Doe 3rd"},
 		{"newline", "John\nDoe", "John\nDoe"},
 		{"leading spaces", "  John", "  John"},
+		{"apostrophe and hyphen", "O'Leary-Brown", "O'Leary-Brown"},
+		{"prefix d'", "d'Artagnan", "d'Artagnan"},
+		{"curly apostrophe", "D’Angelo", "DAngelo"},
+		{"multiple spaces", "Van  der  Meer", "Van  der  Meer"},
+		{"accented surname", "Émilie du Châtelet", "milie du Chtelet"},
+		{"foreign letters", "Björk Guðmundsdóttir", "Bjrk Gumundsdttir"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary
- add more test cases for FormalName including tricky surnames
- extend fuzz seed names for FormalName

## Testing
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make govulncheck` *(fails: GO-2025-3750)*

------
https://chatgpt.com/codex/tasks/task_e_6851b1960e908321b7e4a3645ca679cd