### PR TITLE
[SAN] Simplify URI sanitizer

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -39,7 +39,6 @@ var (
 	ipAddressRegExp       = regexp.MustCompile(`[^a-zA-Z0-9:.]`)                                                           // IPV4 and IPV6 characters only
 	scriptRegExp          = regexp.MustCompile(`(?i)<(script|iframe|embed|object)[^>]*>.*</(script|iframe|embed|object)>`) // Scripts and embeds
 	singleLineRegExp      = regexp.MustCompile(`(\r)|(\n)|(\t)|(\v)|(\f)`)                                                 // Carriage returns, line feeds, tabs, for single line transition
-	uriRegExp             = regexp.MustCompile(`[^a-zA-Z0-9-_/?&=#%]`)                                                     // URI allowed characters
 	urlRegExp             = regexp.MustCompile(`[^a-zA-Z0-9-_/:.,?&@=#%]`)                                                 // URL allowed characters
 	wwwRegExp             = regexp.MustCompile(`(?i)www.`)                                                                 // For removing www
 )
@@ -644,7 +643,16 @@ func Time(original string) string {
 //
 // See more usage examples in the `sanitize_test.go` file.
 func URI(original string) string {
-	return string(uriRegExp.ReplaceAll([]byte(original), emptySpace))
+	var b strings.Builder
+	b.Grow(len(original))
+	for _, r := range original {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) ||
+			r == '-' || r == '_' || r == '/' || r == '?' ||
+			r == '&' || r == '=' || r == '#' || r == '%' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // URL returns a formatted URL-friendly string.


### PR DESCRIPTION
## What Changed
- removed `uriRegExp` and rewrote `URI` sanitizer to iterate over runes

## Why It Was Necessary
- reduce allocations and avoid regex overhead for URI sanitization

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- no API changes; existing tests continue to pass

------
https://chatgpt.com/codex/tasks/task_e_6851b2af0d60832190c5ecb497e2399c