### PR TITLE
[Sanitize] Improve SingleLine performance

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -38,7 +38,6 @@ var (
 	htmlRegExp            = regexp.MustCompile(`(?i)<[^>]*>`)                                                              // HTML/XML tags or any alligator open/close tags
 	ipAddressRegExp       = regexp.MustCompile(`[^a-zA-Z0-9:.]`)                                                           // IPV4 and IPV6 characters only
 	scriptRegExp          = regexp.MustCompile(`(?i)<(script|iframe|embed|object)[^>]*>.*</(script|iframe|embed|object)>`) // Scripts and embeds
-	singleLineRegExp      = regexp.MustCompile(`(\r)|(\n)|(\t)|(\v)|(\f)`)                                                 // Carriage returns, line feeds, tabs, for single line transition
 	wwwRegExp             = regexp.MustCompile(`(?i)www.`)                                                                 // For removing www
 )
 
@@ -593,7 +592,17 @@ func Scripts(original string) string {
 //
 // See more usage examples in the `sanitize_test.go` file.
 func SingleLine(original string) string {
-	return singleLineRegExp.ReplaceAllString(original, " ")
+	var b strings.Builder
+	b.Grow(len(original))
+	for _, r := range original {
+		switch r {
+		case '\r', '\n', '\t', '\v', '\f':
+			b.WriteRune(' ')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // Time returns just the time part of the string.

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1123,6 +1123,28 @@ Work?`))
 	// Output: Does This Work?
 }
 
+// TestSingleLine_EdgeCases tests additional edge cases for SingleLine
+func TestSingleLine_EdgeCases(t *testing.T) {
+
+	var tests = []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty string", "", ""},
+		{"only whitespace", "\n\r\t\v\f", "     "},
+		{"mixed whitespace", "Line1\r\nLine2\tLine3\vLine4\f", "Line1  Line2 Line3 Line4 "},
+		{"leading and trailing", "\nStart\t\n", " Start  "},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := sanitize.SingleLine(test.input)
+			assert.Equal(t, test.expected, output)
+		})
+	}
+}
+
 // TestTime tests the time sanitize method
 func TestTime_Basic(t *testing.T) {
 


### PR DESCRIPTION
## What Changed
- rewrote `SingleLine` to avoid regex and iterate runes
- removed unused `singleLineRegExp`
- added new table-driven edge case tests for `SingleLine`

## Why It Was Necessary
- regex allocation slowed repeated calls
- additional tests ensure consistent behavior for mixed whitespace cases

## Testing Performed
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` covering new scenarios

## Impact / Risk
- no breaking API changes
- slight performance improvement
- minimal risk as logic is equivalent


------
https://chatgpt.com/codex/tasks/task_e_6851b678d124832188a57bf6e3f0d139