### PR TITLE
[SAN] Optimize domain parsing

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -31,11 +31,9 @@ import (
 
 // Set all the regular expressions
 var (
-	domainRegExp = regexp.MustCompile(`[^a-zA-Z0-9-.]`)                                                           // Domain accepted characters
 	emailRegExp  = regexp.MustCompile(`[^a-zA-Z0-9-_.@+]`)                                                        // Email address characters
 	htmlRegExp   = regexp.MustCompile(`(?i)<[^>]*>`)                                                              // HTML/XML tags or any alligator open/close tags
 	scriptRegExp = regexp.MustCompile(`(?i)<(script|iframe|embed|object)[^>]*>.*</(script|iframe|embed|object)>`) // Scripts and embeds
-	wwwRegExp    = regexp.MustCompile(`(?i)www.`)                                                                 // For removing www
 )
 
 // emptySpace is an empty space for replacing
@@ -307,18 +305,28 @@ func Domain(original string, preserveCase bool, removeWww bool) (string, error) 
 		return original, err
 	}
 
+	host := u.Host
+
 	// Remove leading www.
-	if removeWww {
-		u.Host = wwwRegExp.ReplaceAllString(u.Host, "")
+	if removeWww && len(host) >= 4 && strings.EqualFold(host[:4], "www.") {
+		host = host[4:]
 	}
 
-	// Keeps the exact case of the original input string
-	if preserveCase {
-		return string(domainRegExp.ReplaceAll([]byte(u.Host), emptySpace)), nil
+	var b strings.Builder
+	b.Grow(len(host))
+	for _, r := range host {
+		valid := r == '-' || r == '.' || (r >= '0' && r <= '9') ||
+			(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		if !valid {
+			continue
+		}
+		if !preserveCase && r >= 'A' && r <= 'Z' {
+			r += 'a' - 'A'
+		}
+		b.WriteRune(r)
 	}
 
-	// Generally, all domains should be uniform and lowercase
-	return string(domainRegExp.ReplaceAll([]byte(strings.ToLower(u.Host)), emptySpace)), nil
+	return b.String(), nil
 }
 
 // Email returns a sanitized email address string. Email addresses are forced


### PR DESCRIPTION
## What Changed
- refactored `Domain` to avoid regex and reduce allocations
- removed unused domain regex variables

## Why It Was Necessary
- regex-based sanitization caused unnecessary allocations impacting benchmark performance

## Testing Performed
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- No breaking API changes
- Improved runtime performance with minimal risk since tests cover edge cases

------
https://chatgpt.com/codex/tasks/task_e_6851d64a32608321a671aac2eec0eebb