### PR TITLE
[Refactor] Sort functions alphabetically

### DIFF
--- a/sanitize_benchmark_test.go
+++ b/sanitize_benchmark_test.go
@@ -14,13 +14,6 @@ func BenchmarkAlpha(b *testing.B) {
 	}
 }
 
-// BenchmarkAlpha_WithSpaces benchmarks the Alpha method
-func BenchmarkAlpha_WithSpaces(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_ = sanitize.Alpha("This is the test string.", true)
-	}
-}
-
 // BenchmarkAlphaNumeric benchmarks the AlphaNumeric method
 func BenchmarkAlphaNumeric(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -32,6 +25,13 @@ func BenchmarkAlphaNumeric(b *testing.B) {
 func BenchmarkAlphaNumeric_WithSpaces(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = sanitize.AlphaNumeric("This is the test string 12345.", true)
+	}
+}
+
+// BenchmarkAlpha_WithSpaces benchmarks the Alpha method
+func BenchmarkAlpha_WithSpaces(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = sanitize.Alpha("This is the test string.", true)
 	}
 }
 

--- a/sanitize_example_test.go
+++ b/sanitize_example_test.go
@@ -13,12 +13,6 @@ func ExampleAlpha() {
 	// Output: ExampleString
 }
 
-// ExampleAlpha_withSpaces example using Alpha with a space flag
-func ExampleAlpha_withSpaces() {
-	fmt.Println(sanitize.Alpha("Example String!", true))
-	// Output: Example String
-}
-
 // ExampleAlphaNumeric example using AlphaNumeric() with no spaces
 func ExampleAlphaNumeric() {
 	fmt.Println(sanitize.AlphaNumeric("Example String 2!", false))
@@ -29,6 +23,12 @@ func ExampleAlphaNumeric() {
 func ExampleAlphaNumeric_withSpaces() {
 	fmt.Println(sanitize.AlphaNumeric("Example String 2!", true))
 	// Output: Example String 2
+}
+
+// ExampleAlpha_withSpaces example using Alpha with a space flag
+func ExampleAlpha_withSpaces() {
+	fmt.Println(sanitize.Alpha("Example String!", true))
+	// Output: Example String
 }
 
 // ExampleBitcoinAddress example using BitcoinAddress()
@@ -49,17 +49,17 @@ func ExampleCustom() {
 	// Output: ExampleString
 }
 
-// ExampleCustom_numeric example using Custom() using a numeric regex
-func ExampleCustom_numeric() {
-	fmt.Println(sanitize.Custom("Example String 2!", `[^0-9]`))
-	// Output: 2
-}
-
 // ExampleCustomCompiled example using CustomCompiled with an alpha regex
 func ExampleCustomCompiled() {
 	re := regexp.MustCompile(`[^a-zA-Z]`)
 	fmt.Println(sanitize.CustomCompiled("Example String 2!", re))
 	// Output: ExampleString
+}
+
+// ExampleCustom_numeric example using Custom() using a numeric regex
+func ExampleCustom_numeric() {
+	fmt.Println(sanitize.Custom("Example String 2!", `[^0-9]`))
+	// Output: 2
 }
 
 // ExampleDecimal example using Decimal() for a positive number


### PR DESCRIPTION
## What Changed
- reordered benchmark functions alphabetically
- sorted example functions alphabetically
- alphabetized fuzz test functions

## Why It Was Necessary
- maintains consistency with repository conventions
- improves readability of test suites

## Testing Performed
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- no functional changes; low risk

------
https://chatgpt.com/codex/tasks/task_e_6851df87c24c83219c080aa2144df38b