### PR TITLE
[Sanitize] Optimize Email sanitizer

### DIFF
--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -399,7 +399,7 @@ func TestEmail(t *testing.T) {
 		{"email with leading/trailing spaces", "  user@domain.com  ", "user@domain.com", false},
 		{"email with mixed case and preserve", "Test@Domain.COM", "Test@Domain.COM", true},
 		{"email with mixed case and no preserve", "Test@Domain.COM", "test@domain.com", false},
-		{"email with mailto and preserve", "MailTo:Test@Domain.COM", "MailToTest@Domain.COM", true},
+		{"email with mailto and preserve", "MailTo:Test@Domain.COM", "Test@Domain.COM", true},
 		{"email with special chars in local", "user!#$%&'*+/=?^_`{|}~@domain.com", "user+_@domain.com", false},
 		{"email with special chars in domain", "user@do!main.com", "user@domain.com", false},
 		{"email with multiple dots", "user..name@domain.com", "user..name@domain.com", false},


### PR DESCRIPTION
#### What Changed
- Reimplemented `Email` sanitizer using manual rune processing
- Removed unused `emailRegExp` variable
- Updated test for case‑insensitive `mailto:` prefix handling

#### Why It Was Necessary
- Aligns the email sanitizer with the optimized approach used in `Domain`
- Improves performance by avoiding regex allocations
- Ensures prefix removal works regardless of case

#### Testing Performed
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`

#### Impact / Risk
- No breaking API changes
- Low regression risk with updated unit tests
- Minor performance improvement by removing regex usage

------
https://chatgpt.com/codex/tasks/task_e_6851e8a98f048321a3011e793f244c8e