### PR TITLE
[Tests] Add edge case coverage for custom regex sanitizers

### DIFF
--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -202,6 +202,48 @@ func TestCustomCompiled_NilRegex(t *testing.T) {
 	})
 }
 
+// TestCustom_InvalidRegexPanics verifies that Custom panics when given
+// an invalid regular expression pattern.
+func TestCustom_InvalidRegexPanics(t *testing.T) {
+	require.Panics(t, func() {
+		sanitize.Custom("invalid", "(")
+	})
+}
+
+// TestCustom_UnicodePattern ensures Unicode characters are preserved when
+// the regex allows them.
+func TestCustom_UnicodePattern(t *testing.T) {
+	//nolint:gosmopolitan // test includes Unicode characters
+	output := sanitize.Custom("Héllo 世界!123", `[^\p{L}\s]`)
+	//nolint:gosmopolitan // test includes Unicode characters
+	assert.Equal(t, "Héllo 世界", output)
+}
+
+// TestCustom_OverlappingMatches validates behavior when the pattern could
+// match overlapping segments.
+func TestCustom_OverlappingMatches(t *testing.T) {
+	output := sanitize.Custom("ababa", "aba")
+	assert.Equal(t, "ba", output)
+}
+
+// TestCustomCompiled_UnicodePattern ensures Unicode patterns work with
+// precompiled regular expressions.
+func TestCustomCompiled_UnicodePattern(t *testing.T) {
+	re := regexp.MustCompile(`[^\p{L}\s]`)
+	//nolint:gosmopolitan // test includes Unicode characters
+	output := sanitize.CustomCompiled("Héllo 世界!123", re)
+	//nolint:gosmopolitan // test includes Unicode characters
+	assert.Equal(t, "Héllo 世界", output)
+}
+
+// TestCustomCompiled_OverlappingMatches verifies that overlapping matches are
+// handled as expected when using a precompiled regex.
+func TestCustomCompiled_OverlappingMatches(t *testing.T) {
+	re := regexp.MustCompile("aba")
+	output := sanitize.CustomCompiled("ababa", re)
+	assert.Equal(t, "ba", output)
+}
+
 // TestDecimal tests the decimal sanitize method
 func TestDecimal(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What Changed
- Added five new unit tests for `Custom` and `CustomCompiled`
- Covered invalid regex panic, Unicode patterns, and overlapping matches

## Why It Was Necessary
- Existing tests only covered basic cases. These new tests improve robustness by verifying handling of invalid patterns and complex regex scenarios.

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- No production code changes. Adds test coverage only; minimal risk.

------
https://chatgpt.com/codex/tasks/task_e_6852ad656c0483219ef80dce2c68eabc