### PR TITLE
[Tests] Expand numeric sanitization coverage

### DIFF
--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -592,6 +592,9 @@ func TestNumeric(t *testing.T) {
 		{"phone format", "(123) 456-7890", "1234567890"},
 		{"hex prefix", "0xFF 55", "055"},
 		{"spaces only", "   ", ""},
+		{"leading plus", "+12345", "12345"},
+		{"mixed letters digits", "abc123def456", "123456"},
+		{"long numeric string", strings.Repeat("9", 100), strings.Repeat("9", 100)},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## What Changed
- Added new edge case tests for `Numeric` covering leading plus sign, alphanumeric mixes, and long digit strings.

## Why It Was Necessary
- Numeric previously lacked coverage for these cases. The new tests ensure the sanitizer handles unusual numeric inputs correctly.

## Testing Performed
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- Attempted `make run-fuzz-tests` (timed out after 60s)

## Impact / Risk
- No breaking changes or performance impacts expected.

_Assigned to **@mrz1836**_

------
https://chatgpt.com/codex/tasks/task_e_6852ad6e814c83219fffa8f88ad1e4e7