### PR TITLE
[Tests] Add PathName edge cases

### DIFF
--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -621,6 +621,12 @@ func TestPathName(t *testing.T) {
 		{"unicode chars", "naïve.txt", "navetxt"},
 		{"spaces", "dir name/file", "dirnamefile"},
 		{"valid symbols", "filename-123_ABC", "filename-123_ABC"},
+
+		// Additional edge cases
+		{"leading period", ".hiddenfile", "hiddenfile"},
+		{"leading dash", "-dashfile", "-dashfile"},
+		{"consecutive specials", "file--name__", "file--name__"},
+		{"combining characters", "cafe\u0301.txt", "cafetxt"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## What Changed
- added tests for leading periods, leading dashes, consecutive characters and UTF-8 combining accents in `TestPathName`

## Why It Was Necessary
- increase coverage for `PathName` with edge cases like hidden files, consecutive symbols and combining characters

## Testing Performed
- `go fmt ./...`
- `goimports -w sanitize_test.go`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- no breaking changes
- improves test coverage only

------
https://chatgpt.com/codex/tasks/task_e_6852ad777e44832199363710ace2c2ee