### PR TITLE
[sanitize] Add HTML sanitization edge-case tests

### DIFF
--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -501,6 +501,11 @@ func TestHTML(t *testing.T) {
 		{"partial closing", "<div>test</div", "test</div"},
 		{"html comments", "<!-- comment -->text", "text"},
 		{"script tag remains", "<script>alert('x')</script>", "alert('x')"},
+		{"comment with script", "<!--comment--><script>alert('x')</script>text", "alert('x')text"},
+		{"script with comment", "<script><!--evil-->alert('x')</script>", "alert('x')"},
+		{"comment around script", "<!-- <script>alert('x')</script> -->text", "alert('x') -->text"},
+		{"unusual attributes", "<div data-x='1' onload='y'>hello</div>", "hello"},
+		{"nested unclosed", "<div><span>text", "text"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## What Changed
- Added new edge‑case scenarios to `TestHTML` covering comment/script mixtures, unusual attributes, and nested unclosed tags.

## Why It Was Necessary
- Existing tests only covered basic HTML tags and a few malformed inputs. The new cases improve coverage for tricky inputs that could reveal parsing issues.

## Testing Performed
- Ran `go vet`, `golangci-lint`, and `go test ./...`.
- Executed fuzz tests via `make run-fuzz-tests`.
- Ran `make govulncheck` which reported one standard library vulnerability.

## Impact / Risk
- No production code changes; tests only. Low risk with improved confidence in HTML sanitization behavior.


------
https://chatgpt.com/codex/tasks/task_e_6852ad820b3883218eb1623d762e1d50