### PR TITLE
[Test] Expand XML sanitization coverage

### DIFF
--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -926,6 +926,10 @@ func TestXML(t *testing.T) {
 		{"unclosed tag", `<tag>unclosed`, "unclosed"},
 		{"xml header and comment", `<?xml version='1.0'?><!--comment--><a>1</a>`, "1"},
 		{"cdata removed", `<a><![CDATA[test]]></a>`, ""},
+		{"namespaced tag", `<ns:tag>value</ns:tag>`, "value"},
+		{"namespaced root", `<root xmlns:ns='urn'><ns:tag>val</ns:tag></root>`, "val"},
+		{"processing instruction", `<?xml-stylesheet type='text/xsl' href='style.xsl'?><data>something</data>`, "something"},
+		{"malformed nested", `<a><b>value</a></b>`, "value"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### What Changed
- added four table-driven cases in `TestXML` for namespaces, processing instructions and malformed nesting

### Why It Was Necessary
- XML sanitization previously only covered basic tags and CDATA; the new scenarios reveal how the helper handles namespaces and malformed XML

### Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

### Impact / Risk
- no breaking changes; tests improve safety net with minimal performance impact


------
https://chatgpt.com/codex/tasks/task_e_6852b1f042888321b177e5e19d418bae