### PR TITLE
[Docs] Clarify project dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ func main() {
 
 View the generated [documentation](https://pkg.go.dev/github.com/mrz1836/go-sanitize?tab=doc)
 
+> **Heads up!** `go-sanitize` is intentionally light on dependencies. The only
+external package it uses is the excellent `testify` suite—and that's just for
+our tests. You can drop this library into your projects without dragging along
+extra baggage.
+
 <br/>
 
 ### Features


### PR DESCRIPTION
## What Changed
- added a short note in the documentation section calling out that the library has no runtime dependencies and only uses `testify` for tests

## Why It Was Necessary
- clarifies the lightweight nature of the package for new users

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- no code changes; documentation only. Minimal risk.

/assign @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_6852e26a617883218685dae8d8bbbdb8