### PR TITLE
[Docs] Clarify AGENTS.md is canonical for standards

### DIFF
--- a/.github/CODE_STANDARDS.md
+++ b/.github/CODE_STANDARDS.md
@@ -1,34 +1,44 @@
 # Code Standards
 
-This project uses the following code standards and specifications from:
-- [effective go](https://golang.org/doc/effective_go.html)
-- [go benchmarks](https://golang.org/pkg/testing/#hdr-Benchmarks)
-- [go examples](https://golang.org/pkg/testing/#hdr-Examples)
-- [go tests](https://golang.org/pkg/testing/)
-- [godoc](https://godoc.org/golang.org/x/tools/cmd/godoc)
+This library follows cutting-edge Go development practices. The primary authority for workflows and conventions is [AGENTS.md](./AGENTS.md). If guidance here conflicts with that file, defer to **AGENTS.md**.
+
+## Reference Material
+
+We rely on these official resources:
+
+- [Effective Go](https://golang.org/doc/effective_go.html)
+- [Go benchmarks](https://golang.org/pkg/testing/#hdr-Benchmarks)
+- [Go examples](https://golang.org/pkg/testing/#hdr-Examples)
+- [Go tests](https://golang.org/pkg/testing/)
+- [godoc](https://pkg.go.dev/golang.org/x/tools/cmd/godoc)
 - [gofmt](https://golang.org/cmd/gofmt/)
 - [golangci-lint](https://golangci-lint.run/)
-- [report card](https://goreportcard.com/)
+- [Go Report Card](https://goreportcard.com/)
 
-### *effective go* standards
-View the [effective go](https://golang.org/doc/effective_go.html) standards documentation.
+## AGENTS.md
 
-### *golangci-lint* specifications
-The package [golangci-lint](https://golangci-lint.run/usage/quick-start) runs several linters in one package/cmd.
+All coding standards, commit conventions and pull request requirements are defined in [AGENTS.md](./AGENTS.md). Review it before contributing.
 
-View the active linters in the [configuration file](../.golangci.json).
+## Effective Go
 
-Install via macOS:
+Consult the [Effective Go](https://golang.org/doc/effective_go.html) documentation for idiomatic patterns and language conventions.
+
+## golangci-lint
+
+We run [golangci-lint](https://golangci-lint.run/usage/quick-start) to enforce style and complexity rules. Active linters live in [`.golangci.json`](../.golangci.json).
+
+Install on macOS:
 ```shell
 brew install golangci-lint
 ```
 
-Install via Linux and Windows:
+Install on Linux or Windows:
 ```shell
 # binary will be $(go env GOPATH)/bin/golangci-lint
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
 golangci-lint --version
 ```
 
-### *godoc* specifications
-All code is written with documentation in mind. Follow the best practices with naming, examples, and function descriptions.
+## Documentation
+
+All code should be documented for consumption with `godoc` and include concise examples and function comments.


### PR DESCRIPTION
## What Changed
- rewrote `CODE_STANDARDS.md` with a new **AGENTS.md** section
- updated formatting to present references and lint instructions more clearly

## Why It Was Necessary
`CODE_STANDARDS.md` did not mention the repository's main `AGENTS.md`. Linking the canonical rules helps contributors find the authoritative guidelines.

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
Documentation only; no runtime changes. Low risk of regressions.

------
https://chatgpt.com/codex/tasks/task_e_6852e2f5ebbc8321b4a8bad86c3f74d9