### PR TITLE
[CI] Restrict permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
       - 'v*'             # run only on tags that start with "v"
 
 permissions:
-  contents: write        # upload assets and create the release
+  contents: read         # restrict default token to read-only
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,6 +27,8 @@ concurrency:
 
 jobs:
   goreleaser:
+    permissions:
+      contents: write     # required to publish releases
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What Changed
- set the release workflow's default token permissions to read-only
- added a job-level permission block for publishing assets

## Why It Was Necessary
- StepSecurity flagged `contents: write` at the workflow level as overly permissive
- using least privilege reduces the impact of a compromised workflow token

## Testing Performed
- `go fmt ./...`
- `goimports -w $(git ls-files '*.go')`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`
- `make govulncheck` *(reports known standard library issue)*

## Impact / Risk
- no functional change to the release process
- lower default permissions mitigate potential supply chain attacks

------
https://chatgpt.com/codex/tasks/task_e_68544019744c832192327b68c89ee3e9