### PR TITLE
[CI] Restrict token permissions for branch deletion

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -20,11 +20,13 @@ concurrency:
     cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     # Only run if the PR was merged
     if: github.event.pull_request.merged == true
     steps:


### PR DESCRIPTION
## What Changed
- set default `contents: read` permission in `delete-merged-branches.yml`
- grant `contents: write` only to the cleanup job

## Why It Was Necessary
StepSecurity detected that the workflow granted write access at the top level, which violates the principle of least privilege. Restricting the token scope prevents unnecessary repository write permissions.

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- No functional changes to the workflow, but reduced security risk.


------
https://chatgpt.com/codex/tasks/task_e_6854434a57dc83219ba4baed30371d30