### PR TITLE
[CI] Limit permissions for auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -39,11 +39,14 @@ concurrency:
     cancel-in-progress: true
 
 permissions:
-    contents: write
-    pull-requests: write
+    contents: read
+    pull-requests: read
 
 jobs:
     automerge:
+        permissions:
+            contents: write
+            pull-requests: write
         # ← no job‑level bot filter anymore
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
## What Changed
- restricted global GITHUB_TOKEN permissions to read-only in `auto-merge-on-approval.yml`
- added job-level permissions so the automerge step can still merge PRs

## Why It Was Necessary
- top-level `contents` permission was set to `write`, violating least privilege and security guidance

## Testing Performed
- `go fmt ./...`
- `goimports -w $(git ls-files '*.go')`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- no functional changes to library code
- reduces potential attack surface in CI workflows


------
https://chatgpt.com/codex/tasks/task_e_6854437b1d3883219e8f750e62f8c354