### PR TITLE
[CI] Restrict GITHUB_TOKEN permissions in Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,8 +22,8 @@ on:
   status: {}
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 # Cancel older runs of the same PR if a new commit is pushed
 concurrency:
@@ -40,6 +40,9 @@ jobs:
   automerge:
     if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # --- Check if the PR is a minor/patch version bump ---
       - name: Check version bump


### PR DESCRIPTION
## What Changed
- set top-level permissions to read-only
- granted write permissions only for the `automerge` job

## Why It Was Necessary
- security scan flagged global write access in `.github/workflows/dependabot-auto-merge.yml`
- follows least privilege principle

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- no functional changes to library
- reduces potential attack surface


------
https://chatgpt.com/codex/tasks/task_e_6854431a46b88321b7fce9960349e706