### PR TITLE
[CI] Pin action-label-syncer

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -76,7 +76,7 @@ jobs:
       # • GITHUB_TOKEN is required, so the action can call the Labels API.
       # ---------------------------------------------------------------------------
       - name: 🏷️  Sync labels from manifest
-        uses: micnncim/action-label-syncer@v1.3.0
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## What Changed
- pinned `micnncim/action-label-syncer` to commit `3abd5ab72fda571e69fffd97bd4e0033dd5f495c`

## Why It Was Necessary
- ensures workflow integrity by using a specific commit hash

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- minimal; no code changes beyond workflow security hardening

## Notifications
- @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_685443ce75c88321992e6c475ee419b6