### PR TITLE
[CI] Restrict Dependabot merge token

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -41,7 +41,6 @@ jobs:
     if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       pull-requests: write
     steps:
       # --- Check if the PR is a minor/patch version bump ---


### PR DESCRIPTION
## What Changed
- limit `dependabot-auto-merge` job token to only `pull-requests: write`

## Why It Was Necessary
- reduces workflow token permissions per security best practices

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- minimal; job may fail if `contents: write` was required but is now removed

------
https://chatgpt.com/codex/tasks/task_e_685445f2d19883219e6fdc14451fbf47