### PR TITLE
[CI] Pin checkout action in sync-labels workflow

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -65,7 +65,7 @@ jobs:
       #   shallow clone (fetch-depth: 1) is fine.
       # ---------------------------------------------------------------------------
       - name: 🚚  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # ---------------------------------------------------------------------------
       # 2) Synchronize labels


### PR DESCRIPTION
## What Changed
- pin `actions/checkout` to commit SHA in `sync-labels.yml`

## Why It Was Necessary
- StepSecurity flagged the workflow for using an unpinned GitHub Action
- pinning ensures deterministic runs and hardens the workflow

## Testing Performed
- `go fmt ./...`
- `goimports -w $(git ls-files '*.go')`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- No functional changes to library code
- Minimal regression risk; workflow continues to behave the same while improving security.

cc @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_6854461edeb0832199752220e561ef45