### PR TITLE
[CI] Restrict merge workflow permissions

### DIFF
--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -45,7 +45,6 @@ permissions:
 jobs:
     automerge:
         permissions:
-            contents: write
             pull-requests: write
         # ← no job‑level bot filter anymore
         runs-on: ubuntu-latest


### PR DESCRIPTION
## What Changed
- removed unnecessary `contents: write` from auto-merge workflow

## Why It Was Necessary
- avoids granting excess permissions to `GITHUB_TOKEN`

## Testing Performed
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- no functional change to merging behavior
- reduces token scope for improved security

------
https://chatgpt.com/codex/tasks/task_e_685449bf76b483218e10cc3ca66c501f