### PR TITLE
[CI] Restrict token permissions in branch cleanup workflow

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -19,7 +19,8 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
     cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   cleanup:


### PR DESCRIPTION
## What Changed
- limited top-level token permissions to `contents: read`

## Why It Was Necessary
- addresses a StepSecurity warning by minimizing default permissions for the workflow

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run` → no issues
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- minimal: workflow retains ability to delete merged branches with job‑level `contents: write`

------
https://chatgpt.com/codex/tasks/task_e_685449da6070832183935d6b1d223659