### PR TITLE
[CI] Pin stale workflow action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Close stale issues & PRs
-        uses: actions/stale@v9.1.0   # pin the exact tag for reproducibility
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           # —————————————————— Core behaviour ——————————————————
           days-before-stale: 60                 # warn after 60 days


### PR DESCRIPTION
#### What Changed
- Pinned `actions/stale` in `stale.yml` to commit `5bef64f`.

#### Why It Was Necessary
- StepSecurity reported that the workflow used a tag without a full commit SHA, which can lead to unexpected changes.

#### Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`
- `make govulncheck` *(failed: GO-2025-3750 detected)*

#### Impact / Risk
- Low risk. Workflow now references an immutable commit for reproducibility.

------
https://chatgpt.com/codex/tasks/task_e_685449ff82048321971d1372c4dd4c24