### PR TITLE
[CI] Pin gitleaks action by commit

### DIFF
--- a/.github/workflows/check-for-leaks.yml
+++ b/.github/workflows/check-for-leaks.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitleaks scan
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_NOTIFY_USER_LIST: '@mrz1836'


### PR DESCRIPTION
## What Changed
- pinned gitleaks action in `check-for-leaks.yml` using full commit SHA

## Why It Was Necessary
- pinning third-party GitHub Actions improves supply chain security and satisfies project security checks

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- no breaking changes; workflow security tightened


------
https://chatgpt.com/codex/tasks/task_e_68544b16d0dc8321882e0fb9480882ff