### PR TITLE
[CI] Pin checkout action in leak workflow

### DIFF
--- a/.github/workflows/check-for-leaks.yml
+++ b/.github/workflows/check-for-leaks.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## What Changed
- Pinned `actions/checkout` in `check-for-leaks.yml` to a specific commit SHA

## Why It Was Necessary
- Security hardening: pinning GitHub Action versions prevents supply‑chain attacks stemming from implicit version updates

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- No functional changes to code
- Workflow now uses immutable checkout version


------
https://chatgpt.com/codex/tasks/task_e_68544db2b8988321a43b77a063cda611