### PR TITLE
[CI] Pin codecov action by commit

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -136,7 +136,7 @@ jobs:
       # 8. Upload coverage to Codecov
       # ————————————————————————————————————————————————————————————————
       - name: Upload code coverage
-        uses: codecov/codecov-action@v5.4.3
+        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}   # required for private repos
           flags: unittests


### PR DESCRIPTION
## What Changed
- pinned `codecov/codecov-action` to commit `4650159d642e33fdc30954ca22638caf0df6cac8`

## Why It Was Necessary
- addresses security recommendation for pinned dependencies in GitHub workflows

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- no breaking changes
- safer workflow execution by using explicit action version


------
https://chatgpt.com/codex/tasks/task_e_68544debcad08321bda9e61fef47ffe0