### PR TITLE
[CI] Pin codeql upload-sarif action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What Changed
- Pin `github/codeql-action/upload-sarif` to commit `ce28f5bb42b7a9f2c824e633a3f6ee835bab6858` in `scorecard.yml`

## Why It Was Necessary
- Avoids pulling a moving tag for security and reproducibility

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- No breaking changes
- Improves workflow security by pinning a dependency

------
https://chatgpt.com/codex/tasks/task_e_68544dd086d883219c2e87f5fd8b00ca