### PR TITLE
[CI] Pin actions in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -46,7 +46,7 @@ jobs:
       # --- Check if the PR is a minor/patch version bump ---
       - name: Check version bump
         id: bump
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -57,7 +57,7 @@ jobs:
       # --- Alert on major version bump (requires manual review) ---
       - name: Alert on major version bump
         if: steps.bump.outputs.is_minor != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -71,14 +71,14 @@ jobs:
       # --- Auto approve minor/patch version bump PRs ---
       - name: Auto approve minor update
         if: steps.bump.outputs.is_minor == 'true'
-        uses: hmarr/auto-approve-action@v4
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:
           review-message: Automatically approving dependabot pull request
 
       # --- Auto-merge minor/patch version bump PRs ---
       - name: Auto-merge minor update
         if: steps.bump.outputs.is_minor == 'true'
-        uses: pascalgn/automerge-action@v0.16.4
+        uses: pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67 # v0.16.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_LABELS: ""


### PR DESCRIPTION
## What Changed
- pinned `actions/github-script`, `hmarr/auto-approve-action`, and `pascalgn/automerge-action` in `dependabot-auto-merge.yml` to commit SHAs

## Why It Was Necessary
- StepSecurity flagged unpinned third‑party actions; pinning reduces supply‑chain risk

## Testing Performed
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- No functional changes; safer workflow execution


------
https://chatgpt.com/codex/tasks/task_e_68544e7764d083219c2a86ec4c9d3075