### PR TITLE
[Docs] Require pinning of GitHub Actions versions

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -543,6 +543,7 @@ CI automatically runs on every PR to verify:
 * Tests (`go test ./...`)
 * Fuzz tests (if applicable) (`make run-fuzz-tests`)
 * This codebase uses GitHub Actions; test workflows reside in `.github/workflows/run-tests.yml`
+* Pin each external GitHub Action to a **full commit SHA** (e.g., `actions/checkout@2f3b4a2e0e471e13e2ea2bc2a350e888c9cf9b75`) as recommended by GitHub's [security hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-pinned-actions). Dependabot will track and update these pinned versions automatically.
 
 Failing PRs will be blocked. AI agents should iterate until CI passes.
 
@@ -619,6 +620,7 @@ All contributors are expected to append entries here when making meaningful chan
 
 | Date       | Author   | Summary of Changes                                                             |
 |------------|----------|--------------------------------------------------------------------------------|
+| 2025-06-18 | @mrz1836 | Added requirement to pin GitHub Action versions
 | 2025-06-17 | @mrz1836 | Documented Go Fuzz test guidance                                               |
 | 2025-06-16 | @mrz1836 | Adapted to fix this project go-sanitize                                        |
 | 2025-06-04 | @mrz1836 | Documented citation and configuration files for contributors                   |


### PR DESCRIPTION
## What Changed
- Documented requirement to pin external GitHub Actions using full commit SHAs.
- Logged the update in `AGENTS.md` change log.

## Why It Was Necessary
- Aligns repository security practices with GitHub's hardening guidance for workflows.

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- Documentation only; no functional changes.

------
https://chatgpt.com/codex/tasks/task_e_685450111378832182bfffc60f42836a