### PR TITLE
[CI] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -51,7 +51,7 @@ jobs:
 
         steps:
             - name: Attempt auto‑merge
-              uses: actions/github-script@v7
+              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can check out the head.
@@ -43,7 +43,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3

--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # Step 1: Use github-script to run custom JS for branch deletion
       - name: Delete branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add labels based on branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,11 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Write go list
         run: go list -json -m all > go.list
       - name: Ask Nancy
-        uses: sonatype-nexus-community/nancy-github-action@v1.0.3
+        uses: sonatype-nexus-community/nancy-github-action@726e338312e68ecdd4b4195765f174d3b3ce1533 # v1.0.3
         continue-on-error: true
         with:
           nancyCommand: sleuth --loud --exclude-vulnerability CVE-2022-32149
@@ -64,7 +64,7 @@ jobs:
       # 1. Check out the code so we can hash go.mod/go.sum for caching
       # ————————————————————————————————————————————————————————————————
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # ————————————————————————————————————————————————————————————————
       # 2. Install the requested Go version *with built‑in caching enabled*
@@ -73,7 +73,7 @@ jobs:
       #      if you need more than the default `go.sum`
       # ————————————————————————————————————————————————————————————————
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ matrix.go-version }}
           cache: true                   # default, but explicit for clarity
@@ -107,7 +107,7 @@ jobs:
       # 5. Cache golangci-lint analysis
       # ————————————————————————————————————————————————————————————————
       - name: Cache golangci-lint cache
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/golangci-lint
           key: ${{ runner.os }}-golangci-${{ hashFiles('**/*.go', '.golangci.json') }}


### PR DESCRIPTION
## What Changed
- pinned actions in multiple workflows to full commit hashes for reproducible and secure builds

## Why It Was Necessary
- step-security check flagged unpinned third-party actions which pose supply-chain risk

## Testing Performed
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- low; workflows remain functionally identical but now use specific action revisions.

## Notifications
- @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_685450fc7e308321bd4cdd42b37e6463