### PR TITLE
[CI] Add workflow to clean runner caches

### DIFF
--- a/.github/workflows/clean-runner-cache.yml
+++ b/.github/workflows/clean-runner-cache.yml
@@ -1,0 +1,47 @@
+# ------------------------------------------------------------------------------
+#  Clean Runner Cache Workflow
+#
+#  Purpose   : Remove GitHub Actions runner caches when a pull request is closed.
+#
+#  Triggers  : On pull request close events.
+#
+#  Maintainer: @mrz1836
+# ------------------------------------------------------------------------------
+
+name: clean-runner-cache
+
+on:
+  pull_request:
+    types: [closed]
+
+# Cancel older runs of the same PR if a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup caches
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh cache list --ref "$BRANCH" --limit 100 --json id --jq '.[].id')
+
+          # Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete "$cacheKey"
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ vet                   ## Run go vet
 |------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
 | [auto-merge-on-approval.yml](.github/workflows/auto-merge-on-approval.yml)   | Automatically merges PRs after approval and all required checks, following strict rules.                               |
 | [check-for-leaks.yml](.github/workflows/check-for-leaks.yml)                 | Runs gitleaks to detect secrets on a daily schedule.                                                                   |
+| [clean-runner-cache.yml](.github/workflows/clean-runner-cache.yml)           | Removes GitHub Actions caches tied to closed pull requests.                                |
 | [codeql-analysis.yml](.github/workflows/codeql-analysis.yml)                 | Analyzes code for security vulnerabilities using GitHub CodeQL.                                                        |
 | [delete-merged-branches.yml](.github/workflows/delete-merged-branches.yml)   | Deletes feature branches after their pull requests are merged.                                                         |
 | [dependabot-auto-merge.yml](.github/workflows/dependabot-auto-merge.yml)     | Automatically merges Dependabot PRs that meet all requirements.                                                        |


### PR DESCRIPTION
## What Changed
- created `clean-runner-cache.yml` to remove caches when a pull request is closed
- listed the new workflow in the README

## Why It Was Necessary
Old caches for closed pull requests consume storage and slow new runs. Automating cleanup keeps the runner cache lean.

## Testing Performed
- `go test ./...` to ensure library tests still pass

## Impact / Risk
- No breaking changes. Workflow only runs on closed pull requests and uses built‑in GitHub CLI commands.


------
https://chatgpt.com/codex/tasks/task_e_68556744ee6c8321b4ec3a1bfea6f8b0