### PR TITLE
[GitHub] Expand CODEOWNERS rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,22 @@
+# CODEOWNERS
+# See https://docs.github.com/articles/about-codeowners for syntax and rules.
+# The most specific rule that matches takes precedence.
+
+# Default owner for the entire repository
 * @mrz1836
+
+# GitHub Actions workflows
+.github/workflows/* @mrz1836
+
+# Documentation files
+*.md @mrz1836
+CITATION.cff @mrz1836
+
+# Build and makefiles
+Makefile @mrz1836
+.make/*.mk @mrz1836
+*.mk @mrz1836
+
+# Go module dependencies
+go.mod @mrz1836
+go.sum @mrz1836


### PR DESCRIPTION
## What Changed
- extended CODEOWNERS to cover workflows, documentation, Makefiles and Go module files

## Why It Was Necessary
- clarifies code review responsibilities and follows GitHub best practices for code ownership

## Testing Performed
- `golangci-lint run`
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- no breaking changes; documentation update only

------
https://chatgpt.com/codex/tasks/task_e_685571cd44a48321afec04d645efd43b