### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@0.1.3

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@
         </a>
       </td>
       <td valign="top" align="left">
+        <a href="https://dependents.info/mrz1836/go-sanitize">
+          <img src="https://dependents.info/mrz1836/go-sanitize/badge" />
+        </a><br/>
         <a href="https://github.com/mrz1836/go-sanitize/graphs/contributors">
           <img src="https://img.shields.io/github/contributors/mrz1836/go-sanitize?style=flat&logo=contentful&logoColor=white" alt="Contributors">
         </a><br/>
@@ -78,18 +81,32 @@
 <br/>
 
 ## 🗂️ Table of Contents
-* [Installation](#-installation)
-* [Usage](#-usage)
-* [Documentation](#-documentation)
-* [Examples & Tests](#-examples--tests)
-* [Benchmarks](#-benchmarks)
-* [Code Standards](#-code-standards)
-* [AI Compliance](#-ai-compliance)
-* [Maintainers](#-maintainers)
-* [Contributing](#-contributing)
-* [License](#-license)
+- [🛁 go-sanitize](#-go-sanitize)
+  - [🗂️ Table of Contents](#️-table-of-contents)
+  - [🧑‍💻 Used by](#-used-by)
+  - [📦 Installation](#-installation)
+  - [💡 Usage](#-usage)
+  - [📚 Documentation](#-documentation)
+    - [Features](#features)
+    - [Functions](#functions)
+    - [Additional Documentation \& Repository Management](#additional-documentation--repository-management)
+  - [🧪 Examples \& Tests](#-examples--tests)
+  - [⚡ Benchmarks](#-benchmarks)
+    - [Benchmark Results](#benchmark-results)
+  - [🛠️ Code Standards](#️-code-standards)
+  - [🤖 AI Compliance](#-ai-compliance)
+  - [👥 Maintainers](#-maintainers)
+  - [🤝 Contributing](#-contributing)
+    - [How can I help?](#how-can-i-help)
+  - [📝 License](#-license)
 
 <br/>
+
+## 🧑‍💻 Used by
+
+<a href="https://dependents.info/mrz1836/go-sanitize">
+ <img src="https://dependents.info/mrz1836/go-sanitize/image" />
+</a>
 
 ## 📦 Installation
 


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="675" alt="image" src="https://github.com/user-attachments/assets/ba39ba63-f92b-46d4-8c1a-1a65138beafa" />

Please feel free to close the PR if you don't want to have this!