### PR TITLE
[CI] Fix dependabot major bump detection

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -51,7 +51,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const title = context.payload.pull_request.title;
-            const minor = /^Bump[^"]+ from ([\d]+)\..+ to \1\./.test(title);
+            const match = title.match(/from (\d+)(?:\.\d+)* to (\d+)(?:\.\d+)*/i);
+            const minor = match && match[1] === match[2];
             core.setOutput('is_minor', minor);
 
       # --- Alert on major version bump (requires manual review) ---


### PR DESCRIPTION
## What Changed
- Refined regex in `dependabot-auto-merge.yml` to correctly detect major version bumps

## Why It Was Necessary
- Minor Dependabot updates were flagged as major version bumps, requiring unnecessary manual review

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- No breaking changes; improves automation reliability

## Notifications
- @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_685bfa93c9208321b5975a49c285a9a6