### PR TITLE
[CI] Validate Dependabot PR author

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -38,11 +38,27 @@ jobs:
   # Dependabot. For major version bumps, it alerts @mrz1836 for manual review.
   # ------------------------------------------------------------------------------
   automerge:
-    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
+      - name: Validate Dependabot author
+        id: check-author
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const actor = context.payload.pull_request.user.login;
+            const allowed = ['dependabot[bot]', 'dependabot-preview[bot]'].includes(actor);
+            core.setOutput('allowed', allowed);
+            if (!allowed) {
+              core.info(`PR opened by ${actor} - skipping automerge`);
+            }
+
+      - name: Exit for non Dependabot PR
+        if: steps.check-author.outputs.allowed != 'true'
+        run: echo 'Not a Dependabot PR. Exiting.' && exit 0
+
       # --- Check if the PR is a minor/patch version bump ---
       - name: Check version bump
         id: bump


### PR DESCRIPTION
## What Changed
- ensure `dependabot-auto-merge` checks the pull request author instead of event actor
- exit early when the PR was not opened by Dependabot

## Why It Was Necessary
- workflow previously skipped because status events were not authored by Dependabot
- checking the PR owner makes the automation reliable

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- low risk: workflow only merges Dependabot PRs when conditions pass


------
https://chatgpt.com/codex/tasks/task_e_685bfd8f21848321a72659e1348ae5e4