### PR TITLE
[Sanitize] Return error from CustomCompiled

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ extra baggage.
 - [`BitcoinAddress`](sanitize.go): Filter input to valid Bitcoin address characters
 - [`BitcoinCashAddress`](sanitize.go): Filter input to valid Bitcoin Cash address characters
 - [`Custom`](sanitize.go): Use a custom regex to filter input _(legacy)_
-- [`CustomCompiled`](sanitize.go): Use a precompiled regex to filter input **(suggested)**
+- [`CustomCompiled`](sanitize.go): Use a precompiled regex to filter input and return an error if the regex is nil **(suggested)**
 - [`Decimal`](sanitize.go): Keep only decimal or float characters
 - [`Domain`](sanitize.go): Sanitize domain, optionally preserving case and removing www
 - [`Email`](sanitize.go): Normalize an email address

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -31,7 +31,11 @@ func main() {
 
 	// CustomCompiled uses a precompiled regular expression for speed.
 	re := regexp.MustCompile(`[^a-zA-Z]`)
-	log.Printf("CustomCompiled(%q) => %q\n", customIn, sanitize.CustomCompiled(customIn, re))
+	cleanedCustom, err := sanitize.CustomCompiled(customIn, re)
+	if err != nil {
+		log.Fatalf("custom compiled error: %v", err)
+	}
+	log.Printf("CustomCompiled(%q) => %q\n", customIn, cleanedCustom)
 
 	// Decimal keeps digits and decimal separators.
 	decIn := "$ -99.99!"

--- a/sanitize.go
+++ b/sanitize.go
@@ -21,6 +21,7 @@ If you have any suggestions or comments, please feel free to open an issue on th
 package sanitize
 
 import (
+	"errors"
 	"net"
 	"net/url"
 	"regexp"
@@ -37,6 +38,9 @@ var (
 
 // emptySpace is an empty space for replacing
 var emptySpace = []byte("")
+
+// ErrNilRegexp indicates that a nil regular expression was provided.
+var ErrNilRegexp = errors.New("regular expression cannot be nil")
 
 // Alpha returns a string containing only Unicode alphabetic characters from the input.
 // Optionally, it preserves spaces if the `spaces` parameter is set to true.
@@ -208,8 +212,8 @@ func Custom(original string, regExp string) string {
 
 // CustomCompiled returns a sanitized string using a pre-compiled regular
 // expression. This function provides better performance when the same pattern is
-// reused across multiple calls. Passing a nil regular expression will cause a
-// panic.
+// reused across multiple calls. If the provided regular expression is nil, an
+// error is returned.
 //
 // Parameters:
 // - original: The input string to be sanitized.
@@ -217,6 +221,7 @@ func Custom(original string, regExp string) string {
 //
 // Returns:
 // - A sanitized string based on the provided regular expression.
+// - An error if the regular expression is nil.
 //
 // Example:
 //
@@ -228,8 +233,12 @@ func Custom(original string, regExp string) string {
 // See more usage examples in the `sanitize_example_test.go` file.
 // See the benchmarks in the `sanitize_benchmark_test.go` file.
 // See the fuzz tests in the `sanitize_fuzz_test.go` file.
-func CustomCompiled(original string, re *regexp.Regexp) string {
-	return re.ReplaceAllString(original, "")
+func CustomCompiled(original string, re *regexp.Regexp) (string, error) {
+	if re == nil {
+		return "", ErrNilRegexp
+	}
+
+	return re.ReplaceAllString(original, ""), nil
 }
 
 // Decimal returns a sanitized string containing only decimal/float values, including positive and negative numbers.

--- a/sanitize_benchmark_test.go
+++ b/sanitize_benchmark_test.go
@@ -60,7 +60,7 @@ func BenchmarkCustom(b *testing.B) {
 func BenchmarkCustomCompiled(b *testing.B) {
 	re := regexp.MustCompile(`[^a-zA-Z0-9]`)
 	for i := 0; i < b.N; i++ {
-		_ = sanitize.CustomCompiled("This is the test string 12345.", re)
+		_, _ = sanitize.CustomCompiled("This is the test string 12345.", re)
 	}
 }
 

--- a/sanitize_example_test.go
+++ b/sanitize_example_test.go
@@ -52,8 +52,9 @@ func ExampleCustom() {
 // ExampleCustomCompiled example using CustomCompiled with an alpha regex
 func ExampleCustomCompiled() {
 	re := regexp.MustCompile(`[^a-zA-Z]`)
-	fmt.Println(sanitize.CustomCompiled("Example String 2!", re))
-	// Output: ExampleString
+	result, err := sanitize.CustomCompiled("Example String 2!", re)
+	fmt.Println(result, err)
+	// Output: ExampleString <nil>
 }
 
 // ExampleCustom_numeric example using Custom() using a numeric regex

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -191,16 +191,16 @@ func TestCustomCompiled(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				output := sanitize.CustomCompiled(tt.input, tt.re)
+				output, err := sanitize.CustomCompiled(tt.input, tt.re)
+				require.NoError(t, err)
 				require.Equal(t, tt.expected, output)
 			})
 		}
 	})
 
 	t.Run("CustomCompiled_NilRegex", func(t *testing.T) {
-		require.Panics(t, func() {
-			sanitize.CustomCompiled("panic", nil)
-		})
+		_, err := sanitize.CustomCompiled("panic", nil)
+		require.ErrorIs(t, err, sanitize.ErrNilRegexp)
 	})
 
 	t.Run("Custom_InvalidRegexPanics", func(t *testing.T) {


### PR DESCRIPTION
## What Changed
- updated `CustomCompiled` to return `(string, error)` and added `ErrNilRegexp`
- fixed comments, examples, benchmark and README to match new API
- updated unit tests to check for the error case

## Why It Was Necessary
- previous version panicked on nil regex which violated Go error handling best practices
- ensuring consistent error returns improves library reliability

## Testing Performed
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `make govulncheck` *(fails: GO-2025-3750 from standard library)*

## Impact / Risk
- backward incompatible change to `CustomCompiled` signature
- low regression risk due to comprehensive tests


------
https://chatgpt.com/codex/tasks/task_e_685c56269ae4832195c0fcdc7907d126